### PR TITLE
Allow encode_number_precision to be set higher

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -295,7 +295,7 @@ static int json_cfg_encode_number_precision(lua_State *l)
 {
     json_config_t *cfg = json_arg_init(l, 1);
 
-    return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 14);
+    return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 17);
 }
 
 


### PR DESCRIPTION
The default is still 14 sig figs.  By allowing it to be set higher means we can
represent more floats (or ints representable as floats).
